### PR TITLE
Fixes numeric entry bug

### DIFF
--- a/src/lib/states/numeric/numeric-entry-state.js
+++ b/src/lib/states/numeric/numeric-entry-state.js
@@ -1,4 +1,4 @@
-import {ValueState} from '../generic/value-state';
+import { ValueState } from '../generic/value-state';
 
 /**
  * This state supports the entry of a Number value, with possible auto-complete.
@@ -11,7 +11,7 @@ export class NumericEntryState extends ValueState {
     if (config.name === undefined) config.name = 'Enter a value';
     if (config.validate === undefined) {
       config.validate = (val) => {
-        return !isNaN(val.key);
+        return val && !isNaN(val.key);
       };
     }
     config.allowUnknown = true;


### PR DESCRIPTION
If a user clicks the exit button while entering a numeric value into the token it causes an error. The issue is the validate function assumes there is always a value.
Was discovered through this issue below:
https://github.com/uncharted-distil/distil/issues/2777

This was also tested in World Modellers and it appeared there as well.